### PR TITLE
Review docs

### DIFF
--- a/docs/partB/table_bdv_edition_keys.md
+++ b/docs/partB/table_bdv_edition_keys.md
@@ -2,24 +2,24 @@
 
 See also the _'Linking spots'_ and _'Manually adding spots and linking them'_ sections in [this tutorial](../partA/manual_editing.md).
 
-| **Action**                      | **Key**  |
-|---------------------------------|---------------|
-| **_Adding, deleting and modifying spots._** ||
-| Add a new spot. | Put the mouse at the desired position and press the `A` key. |
-| Move a spot.       | Put the mouse inside a spot, press and hold `space`, and move the mouse to the desired position. |
-| Delete a spot. | Put the mouse inside a spot and press `D`. |
-| Change the radius of a spot. | Put the mouse inside a spot and press `Q` (make it smaller) or `E` (bigger.<br>Hold `Shift` to make larger changes or `Control` for finer changes. |
-| **_Adding and linking spots_**. |  |
-| Link one spot to an existing one in the _next_ frame. | Put the mouse **inside** a source spot, and press and hold `L`.<br>The viewer moves to the next time-point and shows a preview of the link.<br>Release the `L` key in the desired target spot. A link is created from the source spot to the target spot. |
-| Link one spot to an existing one in the _previous_ frame. | Same procedure, but press `Shift L`. |
-| Add and link to a spot in the _next_ frame. | Put the mouse **inside** a source spot, and press and hold `A`.<br>The viewer moves to the next time-point, creates a spot there and links it to the source spot<p>While holding `A`, move the new spot to the desired location, and release `A`. |
-| Add and link to a spot in the _previous_ frame. | Same procedure, but press `Shift A`. |
-| Toggle the auto-linking mode. | `Control L` |
-| _**Removing links**_. |  |
-| Delete a link. | Put the mouse over the link to delete and press `D`. |
-| _**Selection editing**_. |  |
-| Add a spot / link to the selection. | `Shift click` on a spot or a link to add / remove it to / from the selection. |
-| Clearing the selection. | Click on an empty place of the image. |
-| Remove selection content. | `Shift delete` |
-| **_Undo / Redo_.**  |                         |
-| Undo / Redo                                               | `Control Z` / `Control Shift Z`                              |
+| **Action**                                                | **Key**                                                                                                                                                                                                                                                   |
+|-----------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **_Adding, deleting and modifying spots._**               |                                                                                                                                                                                                                                                           |
+| Add a new spot.                                           | Put the mouse at the desired position and press the `A` key.                                                                                                                                                                                              |
+| Move a spot.                                              | Put the mouse inside a spot, press and hold `space`, and move the mouse to the desired position.                                                                                                                                                          |
+| Delete a spot.                                            | Put the mouse inside a spot and press `D`.                                                                                                                                                                                                                |
+| Change the radius of a spot.                              | Put the mouse inside a spot and press `Q` (make it smaller) or `E` (bigger).<br>Hold `Shift` to make larger changes or `Control` for finer changes.                                                                                                       |
+| **_Adding and linking spots_**.                           |                                                                                                                                                                                                                                                           |
+| Link one spot to an existing one in the _next_ frame.     | Put the mouse **inside** a source spot, and press and hold `L`.<br>The viewer moves to the next time-point and shows a preview of the link.<br>Release the `L` key in the desired target spot. A link is created from the source spot to the target spot. |
+| Link one spot to an existing one in the _previous_ frame. | Same procedure, but press `Shift L`.                                                                                                                                                                                                                      |
+| Add and link to a spot in the _next_ frame.               | Put the mouse **inside** a source spot, and press and hold `A`.<br>The viewer moves to the next time-point, creates a spot there and links it to the source spot<p>While holding `A`, move the new spot to the desired location, and release `A`.         |
+| Add and link to a spot in the _previous_ frame.           | Same procedure, but press `Shift A`.                                                                                                                                                                                                                      |
+| Toggle the auto-linking mode.                             | `Control L`                                                                                                                                                                                                                                               |
+| _**Removing links**_.                                     |                                                                                                                                                                                                                                                           |
+| Delete a link.                                            | Put the mouse over the link to delete and press `D`.                                                                                                                                                                                                      |
+| _**Selection editing**_.                                  |                                                                                                                                                                                                                                                           |
+| Add a spot / link to the selection.                       | `Shift click` on a spot or a link to add / remove it to / from the selection.                                                                                                                                                                             |
+| Clearing the selection.                                   | Click on an empty place of the image.                                                                                                                                                                                                                     |
+| Remove selection content.                                 | `Shift delete`                                                                                                                                                                                                                                            |
+| **_Undo / Redo_.**                                        |                                                                                                                                                                                                                                                           |
+| Undo / Redo                                               | `Control Z` / `Control Shift Z`                                                                                                                                                                                                                           |

--- a/docs/partB/table_focus_navigation.md
+++ b/docs/partB/table_focus_navigation.md
@@ -1,15 +1,16 @@
-# Track navigation with the Focus.
+# Navigation through lineages in BDV and TrackScheme views.
 
 In BDV and TrackScheme views, the focused spot is the last one selected.
 
-| **Action**                 | **Key**         |
-|----------------------------|-----------------|
-| **_Navigation with the Focus in BDV views._** |                 |
-| Follow a spot across time within a track with the focus.     | `↓` and `↑`     |
-| Jump to the beginning of a branch.| `Alt ↑`         |
-| Jump to the end of a branch.      | `Alt ↓`         |
-| Jump to the beginning of another branch.  | `Control Alt ↑` |
-| Jump to the end of another branch.        | `Control Alt ↓` |
-| **_Navigation with the Focus in TrackScheme._** |                 |
-| Move the focus around from one track or one track branch to another. | `←` and `→`     |
-| Edit the label of the focused spot.       | `Enter`         |
+| **Action**                                                           | **Key**                                                                                                                                                                                   |
+|----------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **_Navigation with the Focus in BDV views._**                        |                                                                                                                                                                                           |
+| Follow a spot across time within a track with the focus.             | `↓` and `↑`                                                                                                                                                                               |
+| Navigate to sibling.                                                 | `←` / `→`. Select and move to the sibling of this spot. A sibling is another spot from the same lineage in the same time-point.<br>Press `Shift` to also add it to the current selection. |
+| Jump to the beginning of a branch.                                   | `Alt ↑`                                                                                                                                                                                   |
+| Jump to the end of a branch.                                         | `Alt ↓`                                                                                                                                                                                   |
+| Jump to the beginning of another branch.                             | `Control Alt ↑`                                                                                                                                                                           |
+| Jump to the end of another branch.                                   | `Control Alt ↓`                                                                                                                                                                           |
+| **_Navigation with the Focus in TrackScheme._**                      |                                                                                                                                                                                           |
+| Move the focus around from one track or one track branch to another. | `←` and `→`                                                                                                                                                                               |
+| Edit the label of the focused spot.                                  | `Enter`                                                                                                                                                                                   |

--- a/docs/partB/table_focus_navigation.md
+++ b/docs/partB/table_focus_navigation.md
@@ -2,15 +2,15 @@
 
 In BDV and TrackScheme views, the focused spot is the last one selected.
 
-| **Action**                                                           | **Key**                                                                                                                                                                                   |
-|----------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **_Navigation with the Focus in BDV views._**                        |                                                                                                                                                                                           |
-| Follow a spot across time within a track with the focus.             | `↓` and `↑`                                                                                                                                                                               |
-| Navigate to sibling.                                                 | `←` / `→`. Select and move to the sibling of this spot. A sibling is another spot from the same lineage in the same time-point.<br>Press `Shift` to also add it to the current selection. |
-| Jump to the beginning of a branch.                                   | `Alt ↑`                                                                                                                                                                                   |
-| Jump to the end of a branch.                                         | `Alt ↓`                                                                                                                                                                                   |
-| Jump to the beginning of another branch.                             | `Control Alt ↑`                                                                                                                                                                           |
-| Jump to the end of another branch.                                   | `Control Alt ↓`                                                                                                                                                                           |
-| **_Navigation with the Focus in TrackScheme._**                      |                                                                                                                                                                                           |
-| Move the focus around from one track or one track branch to another. | `←` and `→`                                                                                                                                                                               |
-| Edit the label of the focused spot.                                  | `Enter`                                                                                                                                                                                   |
+| **Action**                                                                                      | **Key**         |
+|-------------------------------------------------------------------------------------------------|-----------------|
+| **_Navigation with the Focus in BDV views._**                                                   |                 |
+| Follow a spot across time within a track with the focus.                                        | `↓` and `↑`     |
+| Jump to the beginning of another branch.                                                        | `Control Alt ↑` |
+| Jump to the end of another branch.                                                              | `Control Alt ↓` |
+| **_Navigation with the Focus in TrackScheme._**                                                 |                 |
+| Follow a spot across time within a track with the focus.                                        | `↓` and `↑`     |
+| Move the focus around from one track or one track branch to another (i.e. navigate to sibling). | `←` and `→`     |
+| Jump to the beginning of a branch.                                                              | `Alt ↑`         |
+| Jump to the end of a branch.                                                                    | `Alt ↓`         |
+| Edit the label of the focused spot.                                                             | `Enter`         |

--- a/docs/partB/table_trackscheme_edition_keys.md
+++ b/docs/partB/table_trackscheme_edition_keys.md
@@ -1,0 +1,18 @@
+# Editing spots and links in the TrackScheme views.
+
+| Action                              | Key                                                                                                       |
+|-------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| _Editing spots._                    |                                                                                                           |
+| Remove a spot.                      | Press `D` with the mouse inside the spot to remove.                                                       |
+| Edit the label of a spot.           | Press `Enter` when a spot is focused, then enter its label and press `Enter` to validate.                 |
+| _Creating links between spots._     |                                                                                                           |
+| Create a link between two spots.    | Press and hold `L` with the mouse inside the source spot. Release `L` when inside the target spot.        |
+| Remove a link.                      | Press `D` with the mouse on the link to remove.                                                           |
+| _Selection editing._                |                                                                                                           |
+| Add a spot / link to the selection. | `Shift-click` on a spot or a link to add / remove it to / from the selection.                             |
+| Select all in a box.                | `Click and drag` a box.<br>`Shift-click and drag` to add the content of the box to the current selection. |
+| Clearing the selection.             | `Click` on an empty place of the image.                                                                   |
+| Remove selection content.           | `Shift-delete.`                                                                                           |
+| _Undo / redo._                      |                                                                                                           |
+| Undo.                               | `Control-Z`.                                                                                              |
+| Redo.                               | `Control-shift-Z`.                                                                                        |

--- a/index.rst
+++ b/index.rst
@@ -71,6 +71,7 @@ Table of content.
    docs/partB/table_bdv_navigation_keys.md
    docs/partB/table_bdv_edition_keys.md
    docs/partB/table_trackscheme_navigation_keys.md
+   docs/partB/table_trackscheme_edition_keys.md
    docs/partB/table_table_navigation_keys.md
    docs/partB/table_focus_navigation.md
    docs/partB/table_mastodon_selection_keys.md


### PR DESCRIPTION
I reviewed the current status of the documentation available on https://github.com/mastodon-sc/mastodon/ and on https://mastodon.readthedocs.io/en/latest/.
This PR
* adds the editing spots in the trackscheme view that was missing on https://mastodon.readthedocs.io/en/latest/ but would be nice to have there
* makes the differences in navigation with focus between bdv and trackscheme clearer
* adds navigation to sibling to track navigation with the focus section
* fixes a typo