### PR TITLE
Update installation instructions in mastodon_deep_lineage.md

### DIFF
--- a/docs/partC/mastodon_deep_lineage.md
+++ b/docs/partC/mastodon_deep_lineage.md
@@ -1,22 +1,15 @@
 # Mastodon Deep Lineage - a collection of plugins to analyse lineages of tracked objects in Mastodon
 
 ## Installation instructions
-
-* Add the Mastodon-Dev update site in Fiji:
-    * Help > Update > Manage update sites > Add Unlisted Site
-        * Name: Mastodon-Dev
-        * URL: https://sites.imagej.net/Mastodon-Dev/
-        * ![Mastodon Dev update site](deep_lineage/installation/Mastodon-Dev.png)
-* Add the Humble-Video update site in Fiji:
-    * Help > Update > Manage update sites > Add Unlisted Site
-        * Name: Humble-Video
-        * URL: https://sites.imagej.net/Humble-Video/
-        * ![Mastodon Dev update site](deep_lineage/installation/Mastodon-HumbleVideo.png)
-* Add the Mastodon Deep Lineage update site in Fiji:
-    * Help > Update > Manage update sites > Add Unlisted Site
-        * Name: Mastodon-DeepLineage
-        * URL: https://sites.imagej.net/Mastodon-DeepLineage/
-        * ![Mastodon Deep Lineage update site](deep_lineage/installation/Mastodon-DeepLineage.png)
+* Add the listed Mastodon update site in Fiji:
+  * Help > Update > Manage update sites
+    * Name: Mastodon
+    * ![Mastodon Update site](doc/deep_lineage/installation/Mastodon.png)
+* Add the unlisted Mastodon Deep Lineage update site in Fiji:
+  * Help > Update > Manage update sites > Add Unlisted Site
+    * Name: Mastodon-DeepLineage
+    * URL: https://sites.imagej.net/Mastodon-DeepLineage/
+    * ![Mastodon Deep Lineage update site](doc/deep_lineage/installation/Mastodon-DeepLineage.png)
 
 ## Numerical Features added to Mastodon
 


### PR DESCRIPTION
After the beta-28 release, it is currently not required to activate the Mastodon dev update site to get mastodon deep lineage installed.